### PR TITLE
Map permissions for Entur internal token.

### DIFF
--- a/src/main/java/no/rutebanken/baba/security/permissionstore/EnturInternalM2MRoleAssignmentMapper.java
+++ b/src/main/java/no/rutebanken/baba/security/permissionstore/EnturInternalM2MRoleAssignmentMapper.java
@@ -1,0 +1,33 @@
+package no.rutebanken.baba.security.permissionstore;
+
+import org.rutebanken.helper.organisation.RoleAssignment;
+
+import java.util.List;
+
+/**
+ * Build role assignments for Entur Internal machine-to-machine tokens.
+ */
+public class EnturInternalM2MRoleAssignmentMapper {
+
+    static final String DEFAULT_ADMIN_ORG = "RB";
+
+    /**
+     * Extract RoleAssignments from the permission claim.
+     * Internal tokens (from Entur Internal) contain cross-organization roles under this claim.
+     */
+    public List<RoleAssignment> getRolesAssignments(List<String> permissions) {
+        return permissions
+                .stream()
+                .map(role ->
+                        RoleAssignment
+                                .builder()
+                                .withRole(role)
+                                .withOrganisation(DEFAULT_ADMIN_ORG)
+                                .build()
+                )
+                .toList();
+
+
+    }
+
+}

--- a/src/test/java/no/rutebanken/baba/security/permissionstore/EnturInternalM2MRoleAssignmentMapperTest.java
+++ b/src/test/java/no/rutebanken/baba/security/permissionstore/EnturInternalM2MRoleAssignmentMapperTest.java
@@ -1,0 +1,36 @@
+package no.rutebanken.baba.security.permissionstore;
+
+import org.junit.jupiter.api.Test;
+import org.rutebanken.helper.organisation.RoleAssignment;
+
+import java.util.List;
+
+import static no.rutebanken.baba.security.permissionstore.EnturInternalM2MRoleAssignmentMapper.DEFAULT_ADMIN_ORG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnturInternalM2MRoleAssignmentMapperTest {
+
+    @Test
+    void mapEmptyRoleAssignments() {
+        EnturInternalM2MRoleAssignmentMapper mapper = new EnturInternalM2MRoleAssignmentMapper();
+        assertTrue(mapper.getRolesAssignments(List.of()).isEmpty());
+    }
+
+    @Test
+    void mapRoleAssignments() {
+        EnturInternalM2MRoleAssignmentMapper mapper = new EnturInternalM2MRoleAssignmentMapper();
+        List<String> permissions = List.of("a", "b", "c");
+        List<String> roleAssignments = List.of(
+                roleAssignment("a").toString(),
+                roleAssignment("b").toString(),
+                roleAssignment("c").toString()
+        );
+        assertEquals(roleAssignments, mapper.getRolesAssignments(permissions).stream().map(RoleAssignment::toString).toList());
+    }
+
+    private static RoleAssignment roleAssignment(String a) {
+        return RoleAssignment.builder().withOrganisation(DEFAULT_ADMIN_ORG).withRole(a).build();
+    }
+
+}


### PR DESCRIPTION
Refactoring: Map permissions for Entur internal token in UserService. This is currently done in BabaRoleAssignmentExtractor on the permission-store-proxy client side.