### PR TITLE
Remove GEOCODER job domain (geocoder v1 retired)

### DIFF
--- a/src/main/java/no/rutebanken/baba/organisation/rest/dto/user/EventFilterDTO.java
+++ b/src/main/java/no/rutebanken/baba/organisation/rest/dto/user/EventFilterDTO.java
@@ -31,7 +31,6 @@ public class EventFilterDTO {
 
   public enum JobDomain {
     TIMETABLE,
-    GEOCODER,
     GRAPH,
     TIAMAT,
     TIMETABLE_PUBLISH,

--- a/src/main/java/no/rutebanken/baba/organisation/rest/mapper/NotificationConfigurationMapper.java
+++ b/src/main/java/no/rutebanken/baba/organisation/rest/mapper/NotificationConfigurationMapper.java
@@ -18,6 +18,7 @@ package no.rutebanken.baba.organisation.rest.mapper;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import no.rutebanken.baba.organisation.model.CodeSpaceEntity;
@@ -34,11 +35,17 @@ import no.rutebanken.baba.organisation.rest.dto.responsibility.EntityClassificat
 import no.rutebanken.baba.organisation.rest.dto.responsibility.EntityTypeDTO;
 import no.rutebanken.baba.organisation.rest.dto.user.EventFilterDTO;
 import no.rutebanken.baba.organisation.rest.dto.user.NotificationConfigDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 @Service
 public class NotificationConfigurationMapper {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+    NotificationConfigurationMapper.class
+  );
 
   private final EntityClassificationRepository entityClassificationRepository;
 
@@ -70,13 +77,17 @@ public class NotificationConfigurationMapper {
 
     return entity
       .stream()
-      .map(n ->
-        new NotificationConfigDTO(
-          n.getNotificationType(),
-          n.isEnabled(),
-          toDTO(n.getEventFilter(), fullDetails)
-        )
-      )
+      .map(n -> {
+        EventFilterDTO eventFilter = toDTO(n.getEventFilter(), fullDetails);
+        if (eventFilter == null) {
+          // Event filter scoped to a retired/unknown job domain (e.g. GEOCODER after
+          // geocoder v1 was decommissioned). Omit the configuration so reads don't fail;
+          // it is pruned on the user's next save via orphanRemoval.
+          return null;
+        }
+        return new NotificationConfigDTO(n.getNotificationType(), n.isEnabled(), eventFilter);
+      })
+      .filter(Objects::nonNull)
       .collect(Collectors.toSet());
   }
 
@@ -91,10 +102,20 @@ public class NotificationConfigurationMapper {
     EventFilterDTO dto = new EventFilterDTO();
 
     if (eventFilter instanceof JobEventFilter jobEventFilter) {
+      EventFilterDTO.JobDomain jobDomain = parseJobDomain(jobEventFilter.getJobDomain());
+      if (jobDomain == null) {
+        // Stored job domain is no longer a known value (e.g. the retired GEOCODER).
+        // Signal to the caller that this configuration should be omitted.
+        LOGGER.info(
+          "Omitting notification configuration with unknown job domain '{}'",
+          jobEventFilter.getJobDomain()
+        );
+        return null;
+      }
       dto.type = EventFilterDTO.EventFilterType.JOB;
       dto.states = jobEventFilter.getStates();
       dto.actions = jobEventFilter.getActions();
-      dto.jobDomain = EventFilterDTO.JobDomain.valueOf(jobEventFilter.getJobDomain());
+      dto.jobDomain = jobDomain;
     } else if (eventFilter instanceof CrudEventFilter crudEventFilter) {
       dto.type = EventFilterDTO.EventFilterType.CRUD;
       dto.entityClassificationRefs =
@@ -127,6 +148,17 @@ public class NotificationConfigurationMapper {
       }
     }
     return dto;
+  }
+
+  private static EventFilterDTO.JobDomain parseJobDomain(String jobDomain) {
+    if (jobDomain == null) {
+      return null;
+    }
+    try {
+      return EventFilterDTO.JobDomain.valueOf(jobDomain);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
   }
 
   private EntityClassificationDTO toDTO(EntityClassification entity) {

--- a/src/test/java/no/rutebanken/baba/organisation/rest/mapper/NotificationConfigurationMapperTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/mapper/NotificationConfigurationMapperTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.rutebanken.baba.organisation.rest.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import no.rutebanken.baba.organisation.model.user.NotificationConfiguration;
+import no.rutebanken.baba.organisation.model.user.NotificationType;
+import no.rutebanken.baba.organisation.model.user.eventfilter.JobEventFilter;
+import no.rutebanken.baba.organisation.model.user.eventfilter.JobState;
+import no.rutebanken.baba.organisation.rest.dto.user.EventFilterDTO;
+import no.rutebanken.baba.organisation.rest.dto.user.NotificationConfigDTO;
+import org.junit.jupiter.api.Test;
+
+class NotificationConfigurationMapperTest {
+
+  private final NotificationConfigurationMapper mapper = new NotificationConfigurationMapper(
+    null,
+    null,
+    null,
+    null
+  );
+
+  @Test
+  void omitsConfigurationsScopedToRetiredJobDomain() {
+    // A stored filter on the retired GEOCODER domain can no longer be parsed to the
+    // JobDomain enum. The read path must omit it rather than fail, while keeping the
+    // user's other configurations.
+    NotificationConfiguration geocoder = jobConfiguration("GEOCODER");
+    NotificationConfiguration timetable = jobConfiguration("TIMETABLE");
+
+    Set<NotificationConfigDTO> dtos = mapper.toDTO(List.of(geocoder, timetable), false);
+
+    assertEquals(1, dtos.size(), "Configuration on the retired GEOCODER domain should be omitted");
+    assertEquals(
+      EventFilterDTO.JobDomain.TIMETABLE,
+      dtos.iterator().next().eventFilter.jobDomain,
+      "The surviving configuration should be the TIMETABLE one"
+    );
+  }
+
+  @Test
+  void mapsKnownJobDomain() {
+    Set<NotificationConfigDTO> dtos = mapper.toDTO(List.of(jobConfiguration("TIMETABLE")), false);
+
+    assertEquals(1, dtos.size());
+    assertEquals(EventFilterDTO.JobDomain.TIMETABLE, dtos.iterator().next().eventFilter.jobDomain);
+  }
+
+  private static NotificationConfiguration jobConfiguration(String jobDomain) {
+    JobEventFilter eventFilter = new JobEventFilter();
+    eventFilter.setJobDomain(jobDomain);
+    eventFilter.setActions(Set.of("BUILD"));
+    eventFilter.setStates(Set.of(JobState.FAILED));
+
+    NotificationConfiguration configuration = new NotificationConfiguration();
+    configuration.setNotificationType(NotificationType.EMAIL);
+    configuration.setEnabled(true);
+    configuration.setEventFilter(eventFilter);
+    return configuration;
+  }
+}

--- a/src/test/java/no/rutebanken/baba/organisation/rest/validation/NotificationConfigurationValidatorTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/validation/NotificationConfigurationValidatorTest.java
@@ -133,7 +133,9 @@ class NotificationConfigurationValidatorTest {
 
     EventFilterDTO eventFilter = new EventFilterDTO(EventFilterDTO.EventFilterType.JOB);
     eventFilter.actions = Set.of("BUILD");
-    eventFilter.jobDomain = EventFilterDTO.JobDomain.GEOCODER;
+    // Any valid JobDomain works here - this exercises generic JOB-filter validation,
+    // not domain-specific behaviour (GRAPH replaced the retired GEOCODER).
+    eventFilter.jobDomain = EventFilterDTO.JobDomain.GRAPH;
     eventFilter.states = Set.of(JobState.FAILED);
     configDTO.eventFilter = eventFilter;
 


### PR DESCRIPTION
Geocoder v1 (Pelias) is decommissioned. Removes GEOCODER from the
EventFilterDTO.JobDomain enum so it can no longer be selected for
notification event filters, and repoints the affected test fixture.

Stored filters still scoped to GEOCODER are tolerated on read:
NotificationConfigurationMapper omits a notification configuration whose
job domain is no longer a known enum value (instead of failing
JobDomain.valueOf), so existing users' reads don't break. The obsolete
configuration is pruned on the user's next save via orphanRemoval.