### PR TITLE
Normalize user email to lowercase on write

### DIFF
--- a/src/main/java/no/rutebanken/baba/organisation/rest/mapper/UserMapper.java
+++ b/src/main/java/no/rutebanken/baba/organisation/rest/mapper/UserMapper.java
@@ -134,7 +134,7 @@ public class UserMapper implements DTOMapper<User, UserDTO> {
     ContactDetails entity = new ContactDetails();
     entity.setFirstName(dto.firstName);
     entity.setLastName(dto.lastName);
-    entity.setEmail(dto.email);
+    entity.setEmail(dto.email == null ? null : dto.email.toLowerCase());
     entity.setPhone(dto.phone);
     return entity;
   }

--- a/src/test/java/no/rutebanken/baba/organisation/rest/UserResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/UserResourceIntegrationTest.java
@@ -250,6 +250,44 @@ class UserResourceIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  void createUserNormalizesEmailToLowerCase() {
+    ContactDetailsDTO createContactDetails = new ContactDetailsDTO(
+      "first",
+      "last",
+      "phone",
+      "Mixed.Case@Entur.org"
+    );
+    UserDTO createUser = createUser(
+      "mixedCaseEmailUser",
+      TestConstantsOrganisation.ORGANISATION_ID,
+      createContactDetails
+    );
+    URI uri = restTemplate.postForLocation(PATH, createUser);
+    Assertions.assertNotNull(uri);
+
+    UserDTO outUser = restTemplate.getForEntity(uri, UserDTO.class).getBody();
+    Assertions.assertNotNull(outUser);
+    Assertions.assertEquals("mixed.case@entur.org", outUser.contactDetails.email);
+
+    ContactDetailsDTO updateContactDetails = new ContactDetailsDTO(
+      "first",
+      "last",
+      "phone",
+      "Other.Mixed@Entur.NO"
+    );
+    UserDTO updateUser = createUser(
+      createUser.username,
+      createUser.organisationRef,
+      updateContactDetails
+    );
+    restTemplate.put(uri, updateUser);
+
+    UserDTO updatedOutUser = restTemplate.getForEntity(uri, UserDTO.class).getBody();
+    Assertions.assertNotNull(updatedOutUser);
+    Assertions.assertEquals("other.mixed@entur.no", updatedOutUser.contactDetails.email);
+  }
+
+  @Test
   void createInvalidUser() {
     UserDTO inUser = createUser("user name", "privateCode", null);
     ResponseEntity<String> rsp = restTemplate.postForEntity(PATH, inUser, String.class);


### PR DESCRIPTION
## Problem

User emails are stored **as-is** (case preserved) on create/update, but the Entur Partner login path looks them up **lowercased**:

- Write path: `UserMapper#fromDTO` set `dto.email` directly, with no normalization.
- Read path: `UserService#permissionStoreUser` does `permissionStoreUser.email.toLowerCase()` then runs a **case-sensitive** DB lookup (`UserRepositoryImpl#getUserByEmail`, plain `= :email`).

Result: any user whose stored email contains uppercase characters fails to match on login → `NotFoundException` → locked out. Note `toLowerCase()` also lowercases the domain, so a mixed-case domain (e.g. `@Sj.no`) breaks too.

A check against production found **4 users** (of 299) with mixed-case emails currently exposed to this.

## Fix

Lowercase the email in `UserMapper#fromDTO`, mirroring the existing `username.toLowerCase()` convention. Since `updateFromDTO` calls `fromDTO`, this covers both **create** and **update**.

## Existing data

Not included here — the maintainer will run the data normalization manually:

```sql
UPDATE contact_details SET email = lower(email) WHERE email IS NOT NULL AND email <> lower(email);
```

Verified no unique-constraint collisions on prd from lowercasing. (Re-check dev/tst before applying there.)

## Tests

Added `UserResourceIntegrationTest#createUserNormalizesEmailToLowerCase` asserting the email is lowercased on both POST and PUT. All 6 tests in the class pass.