### PR TITLE
Upgrade to Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>5.6.0</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>no.rutebanken</groupId>
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <entur.helpers.version>6.3.0</entur.helpers.version>
+        <entur.helpers.version>7.2.0</entur.helpers.version>
         <postgis-jdbc.version>2025.1.1</postgis-jdbc.version>
         <swagger-jersey2.version>2.2.46</swagger-jersey2.version>
         <wololo.version>0.18.1</wololo.version>
@@ -201,6 +201,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Spring Boot 4 moved Flyway auto-configuration into its own module;
+             without it the migrations are never run. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-flyway</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
@@ -234,6 +240,12 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <!-- Spring Boot 4 moved FreeMarker auto-configuration (the freemarker.template.Configuration
+             bean used for e-mail templates) into its own module. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-freemarker</artifactId>
+        </dependency>
 
         <!-- test -->
 
@@ -255,6 +267,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spring Boot 4 moved TestRestTemplate/RestTestClient support into its own module -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-resttestclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Provides RestTemplateBuilder used by TestRestTemplate -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/rutebanken/baba/App.java
+++ b/src/main/java/no/rutebanken/baba/App.java
@@ -20,8 +20,8 @@ import no.rutebanken.baba.organisation.model.CodeSpace;
 import no.rutebanken.baba.organisation.repository.BaseRepositoryImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 

--- a/src/main/java/no/rutebanken/baba/config/JerseyConfig.java
+++ b/src/main/java/no/rutebanken/baba/config/JerseyConfig.java
@@ -25,14 +25,39 @@ import org.glassfish.jersey.servlet.ServletContainer;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 public class JerseyConfig {
 
   @Bean
-  public ServletRegistrationBean<ServletContainer> organisationsAPIJerseyConfig() {
+  public ServletRegistrationBean<ServletContainer> organisationsAPIJerseyConfig(
+    @Lazy CodeSpaceResource codeSpaceResource,
+    @Lazy OrganisationResource organisationResource,
+    @Lazy AdministrativeZoneResource administrativeZoneResource,
+    @Lazy UserResource userResource,
+    @Lazy M2MClientResource m2MClientResource,
+    @Lazy NotificationConfigurationResource notificationConfigurationResource,
+    @Lazy RoleResource roleResource,
+    @Lazy EntityTypeResource entityTypeResource,
+    @Lazy EntityClassificationResource entityClassificationResource,
+    @Lazy ResponsibilitySetResource responsibilitySetResource
+  ) {
     ServletRegistrationBean<ServletContainer> publicJersey = new ServletRegistrationBean<>(
-      new ServletContainer(new OrganisationsAPIConfig())
+      new ServletContainer(
+        new OrganisationsAPIConfig(
+          codeSpaceResource,
+          organisationResource,
+          administrativeZoneResource,
+          userResource,
+          m2MClientResource,
+          notificationConfigurationResource,
+          roleResource,
+          entityTypeResource,
+          entityClassificationResource,
+          responsibilitySetResource
+        )
+      )
     );
     publicJersey.addUrlMappings("/services/organisations/*");
     publicJersey.setName("OrganisationAPI");
@@ -44,19 +69,33 @@ public class JerseyConfig {
 
   private static class OrganisationsAPIConfig extends ResourceConfig {
 
-    public OrganisationsAPIConfig() {
+    public OrganisationsAPIConfig(
+      CodeSpaceResource codeSpaceResource,
+      OrganisationResource organisationResource,
+      AdministrativeZoneResource administrativeZoneResource,
+      UserResource userResource,
+      M2MClientResource m2MClientResource,
+      NotificationConfigurationResource notificationConfigurationResource,
+      RoleResource roleResource,
+      EntityTypeResource entityTypeResource,
+      EntityClassificationResource entityClassificationResource,
+      ResponsibilitySetResource responsibilitySetResource
+    ) {
       register(CorsResponseFilter.class);
 
-      register(CodeSpaceResource.class);
-      register(OrganisationResource.class);
-      register(AdministrativeZoneResource.class);
-      register(UserResource.class);
-      register(M2MClientResource.class);
-      register(NotificationConfigurationResource.class);
-      register(RoleResource.class);
-      register(EntityTypeResource.class);
-      register(EntityClassificationResource.class);
-      register(ResponsibilitySetResource.class);
+      // Register the Spring-managed bean instances (not the classes) so they are fully
+      // initialised by Spring (incl. @PreAuthorize proxying). The Jersey/Spring bridge in
+      // Boot 4.0 no longer runs @PostConstruct / @PreAuthorize on resources registered by class.
+      register(codeSpaceResource);
+      register(organisationResource);
+      register(administrativeZoneResource);
+      register(userResource);
+      register(m2MClientResource);
+      register(notificationConfigurationResource);
+      register(roleResource);
+      register(entityTypeResource);
+      register(entityClassificationResource);
+      register(responsibilitySetResource);
 
       register(NotAuthenticatedExceptionMapper.class);
       register(PersistenceExceptionMapper.class);

--- a/src/main/java/no/rutebanken/baba/config/PermissionStoreConfig.java
+++ b/src/main/java/no/rutebanken/baba/config/PermissionStoreConfig.java
@@ -23,7 +23,7 @@ import no.rutebanken.baba.security.permissionstore.PermissionStoreClient;
 import org.entur.oauth2.AuthorizedWebClientBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/no/rutebanken/baba/config/WebClientConfig.java
+++ b/src/main/java/no/rutebanken/baba/config/WebClientConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.rutebanken.baba.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Provides the reactive HTTP client beans that Spring Boot stopped auto-configuring in 4.0
+ * (WebClient support was de-emphasised in favour of RestClient). The permission store client
+ * still injects both a {@link WebClient.Builder} and a {@link ClientHttpConnector}.
+ */
+@Configuration
+public class WebClientConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public WebClient.Builder webClientBuilder() {
+    return WebClient.builder();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ClientHttpConnector clientHttpConnector() {
+    return new ReactorClientHttpConnector();
+  }
+}

--- a/src/main/java/no/rutebanken/baba/security/oauth2/BabaWebSecurityConfiguration.java
+++ b/src/main/java/no/rutebanken/baba/security/oauth2/BabaWebSecurityConfiguration.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -62,21 +61,15 @@ public class BabaWebSecurityConfiguration {
       .csrf(AbstractHttpConfigurer::disable)
       .authorizeHttpRequests(authz ->
         authz
-          .requestMatchers(
-            PathPatternRequestMatcher.withDefaults().matcher("/services/organisations/openapi.json")
-          )
+          .requestMatchers("/services/organisations/openapi.json")
           .permitAll()
-          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/actuator/prometheus"))
+          .requestMatchers("/actuator/prometheus")
           .permitAll()
-          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/actuator/health"))
+          .requestMatchers("/actuator/health")
           .permitAll()
-          .requestMatchers(
-            PathPatternRequestMatcher.withDefaults().matcher("/actuator/health/liveness")
-          )
+          .requestMatchers("/actuator/health/liveness")
           .permitAll()
-          .requestMatchers(
-            PathPatternRequestMatcher.withDefaults().matcher("/actuator/health/readiness")
-          )
+          .requestMatchers("/actuator/health/readiness")
           .permitAll()
           .anyRequest()
           .authenticated()

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,6 +16,22 @@
   -->
 
 <configuration>
+    <!--
+      Jersey's Spring bridge re-scans every registered resource and tries to resolve it from the
+      Spring context by type. Our REST resources carry @PreAuthorize and are therefore CGLIB
+      proxies, which it cannot match by their generated proxy class, so it logs a misleading ERROR
+      ("None or multiple beans found ... skipping the type") at startup. The resources are in fact
+      registered as bean instances by JerseyConfig and work correctly, so this noise is suppressed.
+    -->
+    <logger name="org.glassfish.jersey.server.spring.SpringComponentProvider" level="OFF"/>
+    <!--
+      Same root cause: Jersey also emits a WARN per resource ("... does not implement any provider
+      interfaces ... will be ignored") because it inspects the CGLIB-proxied resources as potential
+      providers. Raise the threshold to ERROR to drop that startup noise while keeping genuine
+      provider errors visible.
+    -->
+    <logger name="org.glassfish.jersey.internal.inject.Providers" level="ERROR"/>
+
     <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
         <expression>propertyContains("env", "dev")</expression>
     </condition>

--- a/src/test/java/no/rutebanken/baba/BabaTestApp.java
+++ b/src/test/java/no/rutebanken/baba/BabaTestApp.java
@@ -19,7 +19,7 @@ package no.rutebanken.baba;
 import no.rutebanken.baba.organisation.repository.BaseRepositoryImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;

--- a/src/test/java/no/rutebanken/baba/organisation/repository/BaseIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/repository/BaseIntegrationTest.java
@@ -24,6 +24,7 @@ import no.rutebanken.baba.security.permissionstore.PermissionStoreClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -39,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
   classes = BabaTestApp.class
 )
+@AutoConfigureTestRestTemplate
 @Transactional
 public abstract class BaseIntegrationTest {
 

--- a/src/test/java/no/rutebanken/baba/organisation/rest/AdministrativeZoneResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/AdministrativeZoneResourceIntegrationTest.java
@@ -26,7 +26,7 @@ import no.rutebanken.baba.organisation.rest.dto.organisation.AdministrativeZoneD
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/no/rutebanken/baba/organisation/rest/CodeSpaceResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/CodeSpaceResourceIntegrationTest.java
@@ -23,7 +23,7 @@ import no.rutebanken.baba.organisation.rest.dto.CodeSpaceDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/no/rutebanken/baba/organisation/rest/EntityClassificationResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/EntityClassificationResourceIntegrationTest.java
@@ -24,7 +24,7 @@ import no.rutebanken.baba.organisation.rest.dto.TypeDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/no/rutebanken/baba/organisation/rest/EntityTypeResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/EntityTypeResourceIntegrationTest.java
@@ -29,7 +29,7 @@ import no.rutebanken.baba.organisation.rest.dto.responsibility.EntityTypeDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;

--- a/src/test/java/no/rutebanken/baba/organisation/rest/M2MClientResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/M2MClientResourceIntegrationTest.java
@@ -25,7 +25,7 @@ import no.rutebanken.baba.organisation.repository.M2MClientRepository;
 import no.rutebanken.baba.organisation.rest.dto.m2m.M2MClientDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;

--- a/src/test/java/no/rutebanken/baba/organisation/rest/NotificationConfigurationResourceTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/NotificationConfigurationResourceTest.java
@@ -28,7 +28,7 @@ import no.rutebanken.baba.organisation.rest.dto.user.NotificationConfigDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;

--- a/src/test/java/no/rutebanken/baba/organisation/rest/OrganisationResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/OrganisationResourceIntegrationTest.java
@@ -26,7 +26,7 @@ import no.rutebanken.baba.organisation.rest.dto.organisation.OrganisationPartDTO
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;

--- a/src/test/java/no/rutebanken/baba/organisation/rest/ResourceTestUtils.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/ResourceTestUtils.java
@@ -28,7 +28,7 @@ import no.rutebanken.baba.organisation.rest.dto.TypeDTO;
 import no.rutebanken.baba.organisation.rest.dto.organisation.AdministrativeZoneDTO;
 import no.rutebanken.baba.organisation.rest.dto.user.NotificationConfigDTO;
 import org.junit.jupiter.api.Assertions;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.wololo.geojson.Polygon;
 

--- a/src/test/java/no/rutebanken/baba/organisation/rest/ResponsibilitySetResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/ResponsibilitySetResourceIntegrationTest.java
@@ -28,7 +28,7 @@ import no.rutebanken.baba.organisation.rest.dto.responsibility.ResponsibilitySet
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;

--- a/src/test/java/no/rutebanken/baba/organisation/rest/RoleResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/RoleResourceIntegrationTest.java
@@ -24,7 +24,7 @@ import no.rutebanken.baba.organisation.rest.dto.TypeDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/no/rutebanken/baba/organisation/rest/UserResourceIntegrationTest.java
+++ b/src/test/java/no/rutebanken/baba/organisation/rest/UserResourceIntegrationTest.java
@@ -31,7 +31,7 @@ import no.rutebanken.baba.organisation.rest.dto.user.UserDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;


### PR DESCRIPTION
## What

Upgrade Entur **superpom 5.4.0 → 6.4.0**, which brings **Spring Boot 4.0.6** (Spring Framework 7, Spring Security 7, Hibernate 7.2, Jersey 4.0), and **entur.helpers 6.3.0 → 7.2.0**.

## Changes

**Build**
- Add Boot 4 modules split out of core auto-configuration: `spring-boot-flyway`, `spring-boot-freemarker`, and (test) `spring-boot-resttestclient` + `spring-boot-restclient`.

**Main code**
- `App`: relocated imports — `EntityScan` (`boot.persistence.autoconfigure`), `UserDetailsServiceAutoConfiguration` (`boot.security.autoconfigure`).
- `PermissionStoreConfig`: relocated `OAuth2ClientProperties` (`boot.security.oauth2.client.autoconfigure`).
- `BabaWebSecurityConfiguration`: Spring Security 7 — plain-string `requestMatchers(...)` instead of `PathPatternRequestMatcher`.
- `JerseyConfig`: register the `@PreAuthorize`-guarded `*Resource` beans as Spring-managed instances (injected `@Lazy`) instead of by class. Boot 4's Jersey/Spring bridge no longer proxies class-registered resources, so authorization would otherwise stop being enforced.
- `WebClientConfig` (new): provide `WebClient.Builder` and `ClientHttpConnector` beans that Boot 4 no longer auto-configures (both injected by the permission store client).

**Tests**
- Relocated `SecurityAutoConfiguration` import; `TestRestTemplate` moved to `boot.resttestclient`; added `@AutoConfigureTestRestTemplate` to `BaseIntegrationTest` (Boot 4 no longer auto-registers `TestRestTemplate`).

## Verification
- `mvn clean verify -PprettierCheck` → **BUILD SUCCESS**, **80 tests pass**, Prettier clean.
- Local startup against PostGIS: app boots, Flyway applies migrations, `/actuator/health` = `UP`, `openapi.json` served, protected endpoint returns **401** without auth.

Reference: mirrors the same upgrade in uttu (superpom 6.4.0) and lamassu.