### PR TITLE
Register Jersey resources by class, not proxy instances

### DIFF
--- a/src/main/java/no/rutebanken/baba/config/JerseyConfig.java
+++ b/src/main/java/no/rutebanken/baba/config/JerseyConfig.java
@@ -25,39 +25,14 @@ import org.glassfish.jersey.servlet.ServletContainer;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 
 @Configuration
 public class JerseyConfig {
 
   @Bean
-  public ServletRegistrationBean<ServletContainer> organisationsAPIJerseyConfig(
-    @Lazy CodeSpaceResource codeSpaceResource,
-    @Lazy OrganisationResource organisationResource,
-    @Lazy AdministrativeZoneResource administrativeZoneResource,
-    @Lazy UserResource userResource,
-    @Lazy M2MClientResource m2MClientResource,
-    @Lazy NotificationConfigurationResource notificationConfigurationResource,
-    @Lazy RoleResource roleResource,
-    @Lazy EntityTypeResource entityTypeResource,
-    @Lazy EntityClassificationResource entityClassificationResource,
-    @Lazy ResponsibilitySetResource responsibilitySetResource
-  ) {
+  public ServletRegistrationBean<ServletContainer> organisationsAPIJerseyConfig() {
     ServletRegistrationBean<ServletContainer> publicJersey = new ServletRegistrationBean<>(
-      new ServletContainer(
-        new OrganisationsAPIConfig(
-          codeSpaceResource,
-          organisationResource,
-          administrativeZoneResource,
-          userResource,
-          m2MClientResource,
-          notificationConfigurationResource,
-          roleResource,
-          entityTypeResource,
-          entityClassificationResource,
-          responsibilitySetResource
-        )
-      )
+      new ServletContainer(new OrganisationsAPIConfig())
     );
     publicJersey.addUrlMappings("/services/organisations/*");
     publicJersey.setName("OrganisationAPI");
@@ -69,33 +44,26 @@ public class JerseyConfig {
 
   private static class OrganisationsAPIConfig extends ResourceConfig {
 
-    public OrganisationsAPIConfig(
-      CodeSpaceResource codeSpaceResource,
-      OrganisationResource organisationResource,
-      AdministrativeZoneResource administrativeZoneResource,
-      UserResource userResource,
-      M2MClientResource m2MClientResource,
-      NotificationConfigurationResource notificationConfigurationResource,
-      RoleResource roleResource,
-      EntityTypeResource entityTypeResource,
-      EntityClassificationResource entityClassificationResource,
-      ResponsibilitySetResource responsibilitySetResource
-    ) {
+    public OrganisationsAPIConfig() {
       register(CorsResponseFilter.class);
 
-      // Register the Spring-managed bean instances (not the classes) so they are fully
-      // initialised by Spring (incl. @PreAuthorize proxying). The Jersey/Spring bridge in
-      // Boot 4.0 no longer runs @PostConstruct / @PreAuthorize on resources registered by class.
-      register(codeSpaceResource);
-      register(organisationResource);
-      register(administrativeZoneResource);
-      register(userResource);
-      register(m2MClientResource);
-      register(notificationConfigurationResource);
-      register(roleResource);
-      register(entityTypeResource);
-      register(entityClassificationResource);
-      register(responsibilitySetResource);
+      // Register the resource CLASSES (not bean instances). The resources are constructor-injected
+      // Spring @Components, so Jersey's SpringComponentProvider resolves each one to its single
+      // matching bean - the @PreAuthorize CGLIB proxy - which keeps method-level authorization
+      // working. Registering the proxy *instances* instead would make Jersey introspect the
+      // generated proxy class, which erases the generic BaseResource<E, D> return types
+      // (e.g. listAll(): List<D>) and produces an inaccurate OpenAPI schema plus misleading
+      // startup ERROR/WARN noise.
+      register(CodeSpaceResource.class);
+      register(OrganisationResource.class);
+      register(AdministrativeZoneResource.class);
+      register(UserResource.class);
+      register(M2MClientResource.class);
+      register(NotificationConfigurationResource.class);
+      register(RoleResource.class);
+      register(EntityTypeResource.class);
+      register(EntityClassificationResource.class);
+      register(ResponsibilitySetResource.class);
 
       register(NotAuthenticatedExceptionMapper.class);
       register(PersistenceExceptionMapper.class);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,21 +16,6 @@
   -->
 
 <configuration>
-    <!--
-      Jersey's Spring bridge re-scans every registered resource and tries to resolve it from the
-      Spring context by type. Our REST resources carry @PreAuthorize and are therefore CGLIB
-      proxies, which it cannot match by their generated proxy class, so it logs a misleading ERROR
-      ("None or multiple beans found ... skipping the type") at startup. The resources are in fact
-      registered as bean instances by JerseyConfig and work correctly, so this noise is suppressed.
-    -->
-    <logger name="org.glassfish.jersey.server.spring.SpringComponentProvider" level="OFF"/>
-    <!--
-      Same root cause: Jersey also emits a WARN per resource ("... does not implement any provider
-      interfaces ... will be ignored") because it inspects the CGLIB-proxied resources as potential
-      providers. Raise the threshold to ERROR to drop that startup noise while keeping genuine
-      provider errors visible.
-    -->
-    <logger name="org.glassfish.jersey.internal.inject.Providers" level="ERROR"/>
 
     <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
         <expression>propertyContains("env", "dev")</expression>


### PR DESCRIPTION
Follow-up to #691.

## Problem

#691 switched `JerseyConfig` to register the `@PreAuthorize`-guarded `*Resource` beans as Spring-managed **instances**. Since those beans are `@PreAuthorize` CGLIB proxies, Jersey introspected the generated proxy class, which:

- **Erased the generic `BaseResource<E, D>` return types**, degrading the generated OpenAPI schema:
  - list endpoints (`GET /code_spaces`, `/users`, `/roles`, …) → `array of { "type": "object" }`
  - get-by-id on the `AnnotatedBaseResource` subtypes (`GET /code_spaces/{id}`, `/entity_types/{id}`, …) → `BaseDTO` instead of the concrete DTO
- Produced misleading startup noise — 10 `SpringComponentProvider` ERRORs (`None or multiple beans found … skipping the type`), 10 `Providers` WARNs, and 4 `List<D> is not resolvable to a concrete type` WARNs — which #691 then had to silence in `logback.xml`.

## Fix

Register the resource **classes** again. baba's resources are constructor-injected `@Component`s, so Jersey cannot instantiate them itself — `SpringComponentProvider` resolves each class to its single matching bean (the `@PreAuthorize` proxy). This keeps method-level authorization working **and** lets Jersey introspect the concrete class, restoring the correct OpenAPI schema and removing all the startup noise. The `logback.xml` suppressions added in #691 are therefore removed too.

(The instance-registration pattern came from nabu/uttu, whose resources aren't constructor-injected the same way and genuinely need it — baba does not.)

## Impact on clients

None. Jackson serializes by runtime type, so the JSON payloads were always correct — the regression was confined to the generated OpenAPI doc and the logs. Confirmed by the existing `*ResourceIntegrationTest`s, which assert concrete DTO fields on list and get responses and passed under both versions.

## Verification

- `mvn clean verify -PprettierCheck` → BUILD SUCCESS, 80 tests, 0 failures.
- Local run: clean startup (no Jersey ERROR/WARN noise), secured endpoints return 401, and `openapi.json` now shows concrete DTO schemas for list (`array of CodeSpaceDTO`) and get-by-id (`CodeSpaceDTO`) endpoints.