### PR TITLE
jdk 25 and spring boot 4.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,6 +33,7 @@ jobs:
         run: mvn verify -PprettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
       - uses: actions/upload-artifact@v7.0.1
         with:
+          name: artifact
           path: target/*.jar
       - name: Sonar Scan
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,15 +12,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v5.7.0
         with:
-          java-version: 21.0.5+11
+          java-version: 25.0.4
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v5.1.0
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run maven build
         run: mvn verify -PprettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
-      - uses: actions/upload-artifact@v6.0.0
+      - uses: actions/upload-artifact@v7.0.1
         with:
           path: target/*.jar
       - name: Sonar Scan
@@ -50,6 +50,26 @@ jobs:
                   -Dsonar.projectName=${SONAR_PROJECT_NAME} \
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
+  docker-smoke:
+    needs: [maven-verify]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: artifact
+          path: target
+      - run: docker build -t baba:smoke .
+      # Nothing else in CI runs the image. Reaching Spring's startup line proves the JRE loaded the
+      # application bytecode; it then fails on config that only exists in the cluster, which is fine.
+      # A wrong class file version or an unusable base image never gets that far.
+      - run: |
+          timeout 180 docker run --rm -e SPRING_CLOUD_GCP_SQL_ENABLED=false baba:smoke 2>&1 | tee smoke.log || true
+          grep -q "using Java" smoke.log
+
   docker-build:
     if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [maven-verify]
@@ -58,7 +78,7 @@ jobs:
       build_artifact_name: artifact
       build_artifact_path: target
   docker-push:
-    needs: [docker-build]
+    needs: [docker-build, docker-smoke]
     uses: entur/gha-docker/.github/workflows/push.yml@v1.11.0
 
   helm-lint:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ parent POM is Entur's `org.entur.ror:superpom`.
 
 ## Build, test, run
 
-Java 21. Maven build. The project inherits a **Prettier (prettier-java)** plugin bound to the
+Java 25. Maven build. The project inherits a **Prettier (prettier-java)** plugin bound to the
 `validate` phase that reformats (or in CI, checks) all Java — printWidth 100, 2-space indent.
 
 - **Build:** `mvn clean install`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bellsoft/liberica-openjre-alpine:21.0.12 AS builder
+FROM bellsoft/liberica-openjre-alpine:25.0.4 AS builder
 WORKDIR /builder
 COPY target/*-SNAPSHOT.jar application.jar
 RUN java -Djarmode=tools  -jar application.jar extract --layers --destination extracted
 
-FROM bellsoft/liberica-openjre-alpine:21.0.12
+FROM bellsoft/liberica-openjre-alpine:25.0.4
 RUN apk update && apk upgrade && apk add --no-cache tini
 WORKDIR /deployments
 RUN addgroup appuser && adduser --disabled-password appuser --ingroup appuser

--- a/helm/baba/templates/deployment.yaml
+++ b/helm/baba/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
-              value: -Xmx800m -Dspring.config.location=/etc/application-config/application.properties
+              value: -Xmx800m -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dspring.config.location=/etc/application-config/application.properties
             - name: TZ
               value: Europe/Oslo
           envFrom:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>6.5.0</version>
+        <version>7.0.0</version>
     </parent>
 
     <groupId>no.rutebanken</groupId>
@@ -39,13 +39,12 @@
     </scm>
 
     <properties>
-        <java.version>21</java.version>
         <entur.helpers.version>7.2.0</entur.helpers.version>
         <postgis-jdbc.version>2025.1.1</postgis-jdbc.version>
         <swagger-jersey2.version>2.2.52</swagger-jersey2.version>
         <wololo.version>0.18.1</wololo.version>
         <javax.jdo.jdo-api.version>3.2.1</javax.jdo.jdo-api.version>
-        <spring-cloud-gcp-dependencies.version>7.4.10</spring-cloud-gcp-dependencies.version>
+        <spring-cloud-gcp-dependencies.version>8.1.0</spring-cloud-gcp-dependencies.version>
 
         <rest-assured.version>6.0.1</rest-assured.version>
 


### PR DESCRIPTION
spring-cloud-gcp 8.1.0 is the same code as 7.4.10 rebuilt against Spring Boot 4; 7.4.10 compiles against spring-boot-autoconfigure 3.5.3. The chart gains the JDK 25 native-access and Unsafe flags, guarded by IgnoreUnrecognizedVMOptions so the chart still boots if it ever meets a pre-JDK-24 image. New docker-smoke job starts the built image and gates docker-push, since nothing else in CI runs it.